### PR TITLE
Add ^:const metadata for efficiency

### DIFF
--- a/src/com/gfredericks/seventy_one.clj
+++ b/src/com/gfredericks/seventy_one.clj
@@ -1,6 +1,6 @@
 (ns com.gfredericks.seventy-one
   "Namespace containing seventy-one.")
 
-(def seventy-one
+(def ^:const seventy-one
   "The number seventy-one, i.e. 71."
   71)


### PR DESCRIPTION
For a speed comparison I tried this in the REPL:

``` clojure
(def ^:const seventy-one
  "The number seventy-one, i.e. 71."
  71)

(def seventy-one-not-const 71)
```

``` clojure
com.gfredericks.seventy-one> (time (dotimes [i 1e8] (* i seventy-one-not-const)))
"Elapsed time: 1823.769064 msecs"
nil
com.gfredericks.seventy-one> (time (dotimes [i 1e8] (* i seventy-one)))
"Elapsed time: 190.361232 msecs"
nil
```

You might want to try benchmarking with criterium to be absolute sure of the speed difference, but it's pretty obvious this is an essential performance boost for those looking to use this in production.
