### PR TITLE
Added codox plugin

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,4 +4,5 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [[org.clojure/clojure "1.7.0-RC1"]]
+  :plugins [[codox "0.8.12"]]
   :deploy-repositories [["releases" :clojars]])


### PR DESCRIPTION
I'm envisioning the ["Deploying to GitHub Pages"](https://github.com/weavejester/codox/wiki/Deploying-to-GitHub-Pages) described here in the codox wiki. I've run all the steps on my own fork, and the documentation is visible at: http://aengelberg.github.io/seventy-one

This is where I hand over the reins; after you merge this you can run those commands to start a github pages based workflow described in the guide, and push the documentation whenever new features are added.

(Resolves #4 )
