### PR TITLE
Add Clojure spec

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,15 +3,16 @@
   :url "https://github.com/gfredericks/seventy-one"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.7.0"]]
+  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]]
   :plugins [[codox "0.8.12"]
-            [lein-cljsbuild "1.0.6"]]
+            [lein-cljsbuild "1.1.7"]]
   :deploy-repositories [["releases" :clojars]]
   ;; temporary hack until https://github.com/technomancy/leiningen/issues/1940
   ;; is fixed
   :aliases {"test" ["test" "com.gfredericks.seventy-one-test"]}
-  :profiles {:dev {:dependencies [[org.clojure/clojurescript "0.0-3308"]
-                                  [org.clojure/test.check "0.8.0-RC1"]]
+  :profiles {:dev {:dependencies [[org.clojure/clojurescript "1.9.854"]
+                                  [org.clojure/spec.alpha "0.1.123"]
+                                  [org.clojure/test.check "0.10.0-alpha2"]]
                    :cljsbuild {:builds [{:source-paths ["src" "test"]
                                          :compiler {:output-to "resources/private/js/unit-test.js"
                                                     :optimizations :whitespace

--- a/project.clj
+++ b/project.clj
@@ -7,9 +7,6 @@
   :plugins [[codox "0.8.12"]
             [lein-cljsbuild "1.1.7"]]
   :deploy-repositories [["releases" :clojars]]
-  ;; temporary hack until https://github.com/technomancy/leiningen/issues/1940
-  ;; is fixed
-  :aliases {"test" ["test" "com.gfredericks.seventy-one-test"]}
   :profiles {:dev {:dependencies [[org.clojure/clojurescript "1.9.854"]
                                   [org.clojure/spec.alpha "0.1.123"]
                                   [org.clojure/test.check "0.10.0-alpha2"]]

--- a/src/com/gfredericks/seventy_one.cljc
+++ b/src/com/gfredericks/seventy_one.cljc
@@ -1,5 +1,9 @@
 (ns com.gfredericks.seventy-one
-  "Namespace containing seventy-one.")
+  "Namespace containing seventy-one."
+  (:require
+    [clojure.spec.alpha :as s]))
+
+(s/def ::seventy-one #{71})
 
 (def seventy-one
   "The number seventy-one, i.e. 71."

--- a/test/com/gfredericks/seventy_one_test.cljc
+++ b/test/com/gfredericks/seventy_one_test.cljc
@@ -1,23 +1,26 @@
 (ns com.gfredericks.seventy-one-test
-  (:require #?(:clj [clojure.test :refer :all]
+  (:require [clojure.spec.alpha :as s]
+            #?(:clj [clojure.test :refer :all]
                :cljs [cljs.test :refer-macros [deftest is run-tests]])
-            #?(:clj [clojure.test.check.generators :as gen]
-               :cljs [cljs.test.check.generators :as gen])
-            #?(:clj [clojure.test.check.properties :as prop]
-               :cljs [cljs.test.check.properties :as prop :include-macros true])
-            #?(:clj [clojure.test.check.clojure-test :refer [defspec]]
-               :cljs [cljs.test.check.cljs-test :refer-macros [defspec]])
-            #?(:clj [clojure.test.check :as tc]
-               :cljs [cljs.test.check :as tc])
+            [clojure.test.check.generators :as gen]
+            [clojure.test.check.properties :as prop]
+            [clojure.test.check.clojure-test :refer [defspec]]
+            [clojure.test.check :as tc]
             [com.gfredericks.seventy-one :refer [seventy-one]]))
 
 (deftest seventy-one-test
-  (is (= 71 seventy-one)))
+  (is (= 71 seventy-one))
+  (is (s/valid? :com.gfredericks.seventy-one/seventy-one seventy-one)))
 
 (defspec seventy-one-is-never-not-71
-         100
-         (prop/for-all [v (gen/such-that #(not= % 71) gen/int)]
-                       (not= v seventy-one)))
+  100
+  (prop/for-all [v (gen/such-that #(not= % 71) gen/int)]
+    (not= v seventy-one)))
+
+(defspec seventy-one-is-always-71
+  100
+  (prop/for-all [v (s/gen :com.gfredericks.seventy-one/seventy-one)]
+    (= v 71)))
 
 #?(:cljs
    (do (enable-console-print!)


### PR DESCRIPTION
- Bumped Clojure/ClojureScript versions to 1.9
  - This can be overridden to 1.8 by a consumer of seventy-one, as long as said consumer adds their own dependency on `clojure-future-spec`.
- Bumped lein-cljsbuild and test.check versions accordingly
- Added a `:com.gfredericks.seventy-one/seventy-one` spec that describes the value of the `seventy-one` variable.
- Added a generative test case, verifying values generated from the `::seventy-one` spec are equal to 71.