### PR TITLE
Add namespace with a bunch of useful utils for working with 71

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,12 +3,11 @@
   :url "https://github.com/gfredericks/seventy-one"
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
-  :dependencies [[org.clojure/clojure "1.9.0-alpha17"]]
+  :dependencies [[org.clojure/clojure "1.9.0"]]
   :plugins [[codox "0.8.12"]
             [lein-cljsbuild "1.1.7"]]
   :deploy-repositories [["releases" :clojars]]
-  :profiles {:dev {:dependencies [[org.clojure/clojurescript "1.9.854"]
-                                  [org.clojure/spec.alpha "0.1.123"]
+  :profiles {:dev {:dependencies [[org.clojure/clojurescript "1.9.946"]
                                   [org.clojure/test.check "0.10.0-alpha2"]]
                    :cljsbuild {:builds [{:source-paths ["src" "test"]
                                          :compiler {:output-to "resources/private/js/unit-test.js"

--- a/src/com/gfredericks/seventy_one/util.cljc
+++ b/src/com/gfredericks/seventy_one/util.cljc
@@ -1,0 +1,38 @@
+(ns com.gfredericks.seventy-one.util
+  "Utils to help perform typical operations using the number 71."
+  (:require
+    [clojure.spec.alpha :as s]
+    [clojure.spec.gen.alpha :as gen]
+    [com.gfredericks.seventy-one :as so]))
+
+(defn seventy-one?
+  "Checks whether an object is a number that is equal to seventy
+  one. Returns true for integral and floating-point seventy-ones."
+  [x]
+  (and (number? x)
+       (== x so/seventy-one)))
+
+(def ^:const fast-seventy-one
+  "An alternative to `seventy-one` that is optimized for performance
+  at the expense of dynamism."
+  71)
+
+#?(:clj
+   (defmacro ->71
+     "Threads the expr through the forms. Inserts x as the second item
+  and 71 as the last item in the first form, making a list of it if it
+  is not a list already. If there are more forms, inserts the first
+  form and 71 into the second form, etc."
+     [x & forms]
+     (if-let [[form & more] (seq forms)]
+       (let [form (if (list? form) form (list form))]
+         `(->71
+            (~(first form) ~x ~@(rest form) 71)
+            ~@more))
+       x)))
+
+(defn gen-seventy-one
+  "Returns a clojure.test.check generator that returns 71. Useful for
+  writing robust test cases for code that uses the number 71."
+  []
+  (s/gen ::so/seventy-one))

--- a/src/com/gfredericks/seventy_one/util.cljc
+++ b/src/com/gfredericks/seventy_one/util.cljc
@@ -7,7 +7,8 @@
 
 (defn seventy-one?
   "Checks whether an object is a number that is equal to seventy
-  one. Returns true for integral and floating-point seventy-ones."
+  one. Returns true for integral, decimal, and floating-point
+  seventy-ones."
   [x]
   (and (number? x)
        (== x so/seventy-one)))
@@ -32,7 +33,7 @@
        x)))
 
 (defn gen-seventy-one
-  "Returns a clojure.test.check generator that returns 71. Useful for
-  writing robust test cases for code that uses the number 71."
+  "Returns a clojure.test.check generator that generates 71. Useful
+  for writing robust test cases for code that uses the number 71."
   []
   (s/gen ::so/seventy-one))

--- a/test/com/gfredericks/seventy_one_test.cljc
+++ b/test/com/gfredericks/seventy_one_test.cljc
@@ -6,7 +6,8 @@
             [clojure.test.check.properties :as prop]
             [clojure.test.check.clojure-test :refer [defspec]]
             [clojure.test.check :as tc]
-            [com.gfredericks.seventy-one :refer [seventy-one]]))
+            [com.gfredericks.seventy-one :refer [seventy-one]]
+            [com.gfredericks.seventy-one.util :as util]))
 
 (deftest seventy-one-test
   (is (= 71 seventy-one))
@@ -17,10 +18,43 @@
   (prop/for-all [v (gen/such-that #(not= % 71) gen/int)]
     (not= v seventy-one)))
 
-(defspec seventy-one-is-always-71
+(defspec seventy-one-generator
   100
-  (prop/for-all [v (s/gen :com.gfredericks.seventy-one/seventy-one)]
+  (prop/for-all [v (util/gen-seventy-one)]
     (= v 71)))
+
+(deftest seventy-one?-returns-true-if-it-is-seventy-one
+  (is (true? (util/seventy-one? 71)))
+  (is (true? (util/seventy-one? 71.0)))
+  (is (true? (util/seventy-one? seventy-one))))
+
+(defspec seventy-one?-returns-false-if-it-isn't-seventy-one
+  100
+  (prop/for-all [v (gen/such-that
+                     (complement #{71 71.0})
+                     gen/any)]
+    (false? (util/seventy-one? v))))
+
+(deftest ->71-test
+  (is (= [:a 3 "hi" 71 71]
+         (util/->71 [:a 3 "hi"]
+                    conj
+                    conj)))
+  (is (= {:k1 71 :k2 71}
+         (util/->71 {}
+                    (assoc :k1)
+                    (assoc :k2))))
+  (is (= #{71}
+         (util/->71 #{}
+                    conj
+                    disj
+                    conj)))
+  (is (= 30246
+         (util/->71 4
+                    *
+                    +
+                    +
+                    *))))
 
 #?(:cljs
    (do (enable-console-print!)


### PR DESCRIPTION
Based on the discussion in #16, it's clear that there is a need for helper functions to simplify common operations with the number 71, but if we go that route, they should be in a separate dedicated namespace. So in this pull request I created `com.gfredericks.seventy-one.util` which has four new exciting functions, including `fast-seventy-one` per Gary's suggestion in #2.